### PR TITLE
Install packages for emulator build

### DIFF
--- a/openjdk-8/artful/Dockerfile
+++ b/openjdk-8/artful/Dockerfile
@@ -25,6 +25,12 @@ RUN dpkg --add-architecture i386 \
 		unzip \
 		wget \
 		zip \
+	&& apt-get install --no-install-recommends -y \
+		locales \
+		lsb-release \
+		pbzip2 \
+	&& sed 's,^# fr_FR.UTF-8 UTF-8,fr_FR.UTF-8 UTF-8,' -i /etc/locale.gen \
+	&& locale-gen \
 	&& apt-get clean \
 	&& rm -f /var/lib/apt/lists/*_dists_*
 

--- a/openjdk-8/bionic/Dockerfile
+++ b/openjdk-8/bionic/Dockerfile
@@ -25,6 +25,12 @@ RUN dpkg --add-architecture i386 \
 		unzip \
 		wget \
 		zip \
+	&& apt-get install --no-install-recommends -y \
+		locales \
+		lsb-release \
+		pbzip2 \
+	&& sed 's,^# fr_FR.UTF-8 UTF-8,fr_FR.UTF-8 UTF-8,' -i /etc/locale.gen \
+	&& locale-gen \
 	&& apt-get clean \
 	&& rm -f /var/lib/apt/lists/*_dists_*
 

--- a/openjdk-8/buster/Dockerfile
+++ b/openjdk-8/buster/Dockerfile
@@ -25,6 +25,12 @@ RUN dpkg --add-architecture i386 \
 		unzip \
 		wget \
 		zip \
+	&& apt-get install --no-install-recommends -y \
+		locales \
+		lsb-release \
+		pbzip2 \
+	&& sed 's,^# fr_FR.UTF-8 UTF-8,fr_FR.UTF-8 UTF-8,' -i /etc/locale.gen \
+	&& locale-gen \
 	&& apt-get clean \
 	&& rm -f /var/lib/apt/lists/*_dists_*
 

--- a/openjdk-8/cosmic/Dockerfile
+++ b/openjdk-8/cosmic/Dockerfile
@@ -25,6 +25,12 @@ RUN dpkg --add-architecture i386 \
 		unzip \
 		wget \
 		zip \
+	&& apt-get install --no-install-recommends -y \
+		locales \
+		lsb-release \
+		pbzip2 \
+	&& sed 's,^# fr_FR.UTF-8 UTF-8,fr_FR.UTF-8 UTF-8,' -i /etc/locale.gen \
+	&& locale-gen \
 	&& apt-get clean \
 	&& rm -f /var/lib/apt/lists/*_dists_*
 

--- a/openjdk-8/jessie/Dockerfile
+++ b/openjdk-8/jessie/Dockerfile
@@ -27,6 +27,12 @@ RUN dpkg --add-architecture i386 \
 		unzip \
 		wget \
 		zip \
+	&& apt-get install --no-install-recommends -y \
+		locales \
+		lsb-release \
+		pbzip2 \
+	&& sed 's,^# fr_FR.UTF-8 UTF-8,fr_FR.UTF-8 UTF-8,' -i /etc/locale.gen \
+	&& locale-gen \
 	&& apt-get clean \
 	&& rm -f /var/lib/apt/lists/*_dists_*
 

--- a/openjdk-8/sid/Dockerfile
+++ b/openjdk-8/sid/Dockerfile
@@ -25,6 +25,12 @@ RUN dpkg --add-architecture i386 \
 		unzip \
 		wget \
 		zip \
+	&& apt-get install --no-install-recommends -y \
+		locales \
+		lsb-release \
+		pbzip2 \
+	&& sed 's,^# fr_FR.UTF-8 UTF-8,fr_FR.UTF-8 UTF-8,' -i /etc/locale.gen \
+	&& locale-gen \
 	&& apt-get clean \
 	&& rm -f /var/lib/apt/lists/*_dists_*
 

--- a/openjdk-8/stretch/Dockerfile
+++ b/openjdk-8/stretch/Dockerfile
@@ -27,6 +27,12 @@ RUN dpkg --add-architecture i386 \
 		unzip \
 		wget \
 		zip \
+	&& apt-get install --no-install-recommends -y \
+		locales \
+		lsb-release \
+		pbzip2 \
+	&& sed 's,^# fr_FR.UTF-8 UTF-8,fr_FR.UTF-8 UTF-8,' -i /etc/locale.gen \
+	&& locale-gen \
 	&& apt-get clean \
 	&& rm -f /var/lib/apt/lists/*_dists_*
 

--- a/openjdk-8/trusty/Dockerfile
+++ b/openjdk-8/trusty/Dockerfile
@@ -27,6 +27,12 @@ RUN dpkg --add-architecture i386 \
 		unzip \
 		wget \
 		zip \
+	&& apt-get install --no-install-recommends -y \
+		locales \
+		lsb-release \
+		pbzip2 \
+	&& (echo "fr_FR.UTF-8 UTF-8" | tee /var/lib/locales/supported.d/android) \
+	&& dpkg-reconfigure locales \
 	&& apt-get clean \
 	&& rm -f /var/lib/apt/lists/*_dists_*
 

--- a/openjdk-8/xenial/Dockerfile
+++ b/openjdk-8/xenial/Dockerfile
@@ -25,6 +25,12 @@ RUN dpkg --add-architecture i386 \
 		unzip \
 		wget \
 		zip \
+	&& apt-get install --no-install-recommends -y \
+		locales \
+		lsb-release \
+		pbzip2 \
+	&& sed 's,^# fr_FR.UTF-8 UTF-8,fr_FR.UTF-8 UTF-8,' -i /etc/locale.gen \
+	&& locale-gen \
 	&& apt-get clean \
 	&& rm -f /var/lib/apt/lists/*_dists_*
 


### PR DESCRIPTION
Install packages necessary for build/test emulator built from emu-*-release branches.

Note that IPv6 is also mandatory to pass all emulator unit tests. To enable IPv6, add following configs to /etc/docker/daemon.json and restart docker service:

```
{
  "ipv6": true,
  "fixed-cidr-v6": "2001:db8:1::/64"
}
```

See also https://docs.docker.com/v17.09/engine/userguide/networking/default_network/ipv6/