### PR TITLE
ci: mark buster-openjdk-8 as known failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+  - env: VERSION=openjdk-8/buster
 
 branches:
   only:


### PR DESCRIPTION
See #12.